### PR TITLE
Add support for custom resolvers as well

### DIFF
--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -2,7 +2,6 @@ name: Scala CI
 
 on:
   push:
-  pull_request:
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ You can override `publishTo` if the defaults don't work for you.
 You can also add custom Artifactory resolvers for dependency resolution.
 
 ```sbt
-resolvers += Resolver.artifactoryIvyRepo("ivy-release").value
-resolvers += Resolver.artifactoryRepo("maven-release").value
+resolvers += Resolver.artifactoryIvyRepo(artifactory.value, "ivy-release")
+resolvers += Resolver.artifactoryRepo(artifactory.value, "maven-release")
 ```
 
 ## sbt keys

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Scala CI](https://github.com/jrouly/sbt-artifactory/workflows/Scala%20CI/badge.svg?branch=master)](https://github.com/jrouly/sbt-artifactory/actions?query=workflow%3A%22Scala+CI%22)
 [![version](https://img.shields.io/badge/version-0.2.0-blue)](https://github.com/jrouly/sbt-artifactory/releases)
 
-A tiny sbt plugin to streamline publishing to [JFrog Artifactory](https://jfrog.com/artifactory/).
+A tiny sbt plugin to streamline resolving against [JFrog Artifactory](https://jfrog.com/artifactory/).
 Motivated by the [sunsetting of Bintray](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/).
 
 This plugin [uses itself to publish itself](project/plugins.sbt#L4-L6).
@@ -14,7 +14,7 @@ Add to your `project/plugins.sbt`
 
 ```sbt
 resolvers += Resolver.url("ivy-release-local", url(s"https://jrouly.jfrog.io/artifactory/ivy-release-local"))(Resolver.ivyStylePatterns)
-addSbtPlugin("io.jrouly" % "sbt-artifactory" % "version")
+addSbtPlugin("net.rouly" % "sbt-artifactory" % "version")
 ```
 
 ## Credentials
@@ -34,18 +34,24 @@ The default credential realm is set to `Artifactory Realm` but this can be overr
 Configure the connection for your Artifactory install.
 
 ```sbt
-artifactoryConnection := artifactoryCloud("mycompany") // https://mycompany.jfrog.io
-artifactoryConnection := artifactoryHttps("artifacts.mycompany.biz")
-artifactoryConnection := artifactoryHttps("artifacts.mycompany.biz", "/custom/path/to/artifactory")
-artifactoryConnection := artifactoryHttp("insecure.artifacts.mycompany.biz")
-artifactoryConnection := artifactoryHttp("insecure.artifacts.mycompany.biz", "/custom/path/to/artifactory")
+artifactory := artifactoryCloud("mycompany") // https://mycompany.jfrog.io
+artifactory := artifactoryHttps("artifacts.mycompany.biz")
+artifactory := artifactoryHttps("artifacts.mycompany.biz", "/custom/path/to/artifactory")
+artifactory := artifactoryHttp("insecure.artifacts.mycompany.biz")
+artifactory := artifactoryHttp("insecure.artifacts.mycompany.biz", "/custom/path/to/artifactory")
 ```
+
+#### A note about http
+
+It is recommended to use `https` for artifact resolution.
+No guarantee is made that `http` will work for sbt versions `0.13` and below.
 
 ### Repository names
 
 By default, the plugin will anticipate the repository names `ivy-{snapshot|release}-local` and `maven-{snapshot|release}-local` based on the value of `publishMavenStyle`.
 
 If these don't work for you, you can override the settings.
+
 ```sbt
 artifactorySnapshotRepository := "sbt-snapshot"
 artifactoryReleaseRepository := "sbt-release"
@@ -53,11 +59,27 @@ artifactoryReleaseRepository := "sbt-release"
 
 If you use a single repository for both snapshots and releases, just set the keys to the same value.
 
+### Publishing
+
+`publishTo` is automagically configured for you.
+It is aware of snapshot/release and ivy/maven settings by default.
+
+You can override `publishTo` if the defaults don't work for you.
+
+### Resolving
+
+You can also add custom Artifactory resolvers for dependency resolution.
+
+```sbt
+resolvers += Resolver.artifactoryIvyRepo("ivy-release").value
+resolvers += Resolver.artifactoryRepo("maven-release").value
+```
+
 ## sbt keys
 
 | Key | Type | Description |
 | --- | ---- | ----------- |
-| `artifactoryConnection` | `ArtifactoryConnection` | Artifactory connection configuration. |
+| `artifactory` | `ArtifactoryConnection` | Artifactory connection configuration. |
 | `artifactoryRealm` | `String` | Artifactory credential realm. Defaults to `Artifactory Realm`. |
 | `artifactorySnapshotRepository` | `String` | Artifactory snapshot repository label. Defaults to `ivy-snapshot-local` or `maven-snapshot-local`. |
 | `artifactoryReleaseRepository` | `String` | Artifactory release repository label. Defaults to `ivy-release-local` or `maven-release-local`. |

--- a/build.sbt
+++ b/build.sbt
@@ -25,12 +25,8 @@ enablePlugins(SbtPlugin)
 sbtPlugin := true
 
 crossSbtVersions := List(
-  "0.13.17",
   "0.13.18",
   "1.0.4",
-  "1.1.6",
-  "1.2.8",
-  "1.3.13",
   "1.4.9"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 name := "sbt-artifactory"
-organization := "io.jrouly"
+organization := "net.rouly"
 description := "Streamlines JFrog Artifactory integration."
 
 licenses += ("The Apache Software License, Version 2.0", url("https://www.apache.org/licenses/LICENSE-2.0.txt"))
@@ -23,7 +23,16 @@ scmInfo := Some(
 
 enablePlugins(SbtPlugin)
 sbtPlugin := true
-crossSbtVersions := List("0.13.18", "1.4.6")
+
+crossSbtVersions := List(
+  "0.13.17",
+  "0.13.18",
+  "1.0.4",
+  "1.1.6",
+  "1.2.8",
+  "1.3.13",
+  "1.4.9"
+)
 
 publishMavenStyle := false
 artifactoryConnection := artifactoryCloud("jrouly")

--- a/src/main/scala-sbt-0.13/io/jrouly/sbt/artifactory/HandleInsecure.scala
+++ b/src/main/scala-sbt-0.13/io/jrouly/sbt/artifactory/HandleInsecure.scala
@@ -1,7 +1,0 @@
-package io.jrouly.sbt.artifactory
-
-import sbt._
-
-private object HandleInsecure {
-  def apply(resolver: URLRepository, allowInsecure: Boolean): URLRepository = resolver
-}

--- a/src/main/scala-sbt-1.0/io/jrouly/sbt/artifactory/HandleInsecure.scala
+++ b/src/main/scala-sbt-1.0/io/jrouly/sbt/artifactory/HandleInsecure.scala
@@ -1,9 +1,0 @@
-package io.jrouly.sbt.artifactory
-
-import sbt._
-
-private object HandleInsecure {
-  def apply(resolver: URLRepository, allowInsecure: Boolean): URLRepository = {
-    resolver.withAllowInsecureProtocol(allowInsecure)
-  }
-}

--- a/src/main/scala/net/rouly/sbt/artifactory/Artifactory.scala
+++ b/src/main/scala/net/rouly/sbt/artifactory/Artifactory.scala
@@ -1,0 +1,24 @@
+package net.rouly.sbt.artifactory
+
+import sbt._
+
+private object Artifactory {
+
+  def connection(
+    connection: ArtifactoryConnection,
+    repository: String
+  )(implicit patterns: Patterns): URLRepository = {
+    val repositoryUrl: String = {
+      connection match {
+        case ArtifactoryUrl(protocol, hostname, port, path) =>
+          val cleanProtocol = protocol.stripSuffix("://")
+          val cleanPath = path.stripPrefix("/").stripSuffix("/")
+          s"$cleanProtocol://$hostname:$port/$cleanPath/$repository"
+        case cloud@ArtifactoryCloud(_) =>
+          s"https://${cloud.hostname}/artifactory/$repository"
+      }
+    }
+
+    Resolver.url(repository, url(repositoryUrl))
+  }
+}

--- a/src/main/scala/net/rouly/sbt/artifactory/ArtifactoryConnection.scala
+++ b/src/main/scala/net/rouly/sbt/artifactory/ArtifactoryConnection.scala
@@ -1,4 +1,4 @@
-package io.jrouly.sbt.artifactory
+package net.rouly.sbt.artifactory
 
 sealed trait ArtifactoryConnection {
   def hostname: String

--- a/src/main/scala/net/rouly/sbt/artifactory/ArtifactoryImplicits.scala
+++ b/src/main/scala/net/rouly/sbt/artifactory/ArtifactoryImplicits.scala
@@ -1,0 +1,22 @@
+package net.rouly.sbt.artifactory
+
+import sbt._
+
+trait ArtifactoryImplicits extends ArtifactoryPluginKeys {
+
+  implicit class ArtifactoryResolverCompanion(companion: Resolver.type) {
+
+    /** Artifact resolver for JFrog Artifactory. Maven style resolution. */
+    def artifactoryRepo(repo: String): Def.Initialize[sbt.URLRepository] = Def.setting {
+      implicit val patterns: Patterns = Resolver.mavenStylePatterns
+      Artifactory.connection(artifactory.value, repo)
+    }
+
+    /** Artifact resolver for JFrog Artifactory. Ivy style resolution. */
+    def artifactoryIvyRepo(repo: String): Def.Initialize[sbt.URLRepository] = Def.setting {
+      implicit val patterns: Patterns = Resolver.ivyStylePatterns
+      Artifactory.connection(artifactory.value, repo)
+    }
+  }
+
+}

--- a/src/main/scala/net/rouly/sbt/artifactory/ArtifactoryImplicits.scala
+++ b/src/main/scala/net/rouly/sbt/artifactory/ArtifactoryImplicits.scala
@@ -2,20 +2,20 @@ package net.rouly.sbt.artifactory
 
 import sbt._
 
-trait ArtifactoryImplicits extends ArtifactoryPluginKeys {
+trait ArtifactoryImplicits {
 
   implicit class ArtifactoryResolverCompanion(companion: Resolver.type) {
 
     /** Artifact resolver for JFrog Artifactory. Maven style resolution. */
-    def artifactoryRepo(repo: String): Def.Initialize[sbt.URLRepository] = Def.setting {
+    def artifactoryRepo(artifactory: ArtifactoryConnection, repo: String): URLRepository = {
       implicit val patterns: Patterns = Resolver.mavenStylePatterns
-      Artifactory.connection(artifactory.value, repo)
+      Artifactory.connection(artifactory, repo)
     }
 
     /** Artifact resolver for JFrog Artifactory. Ivy style resolution. */
-    def artifactoryIvyRepo(repo: String): Def.Initialize[sbt.URLRepository] = Def.setting {
+    def artifactoryIvyRepo(artifactory: ArtifactoryConnection, repo: String): URLRepository = {
       implicit val patterns: Patterns = Resolver.ivyStylePatterns
-      Artifactory.connection(artifactory.value, repo)
+      Artifactory.connection(artifactory, repo)
     }
   }
 

--- a/src/main/scala/net/rouly/sbt/artifactory/ArtifactoryPlugin.scala
+++ b/src/main/scala/net/rouly/sbt/artifactory/ArtifactoryPlugin.scala
@@ -62,16 +62,18 @@ object ArtifactoryPlugin extends AutoPlugin {
       else "ivy-release-local"
     },
 
-    artifactorySnapshotResolver := Def.settingDyn {
+    artifactorySnapshotResolver := {
       val repository = artifactorySnapshotRepository.value
-      if (Keys.publishMavenStyle.value) Resolver.artifactoryRepo(repository)
-      else Resolver.artifactoryIvyRepo(repository)
-    }.value,
+      val connection = artifactory.value
+      if (Keys.publishMavenStyle.value) Resolver.artifactoryRepo(connection, repository)
+      else Resolver.artifactoryIvyRepo(connection, repository)
+    },
 
-    artifactoryReleaseResolver := Def.settingDyn {
+    artifactoryReleaseResolver := {
       val repository = artifactoryReleaseRepository.value
-      if (Keys.publishMavenStyle.value) Resolver.artifactoryRepo(repository)
-      else Resolver.artifactoryIvyRepo(repository)
-    }.value
+      val connection = artifactory.value
+      if (Keys.publishMavenStyle.value) Resolver.artifactoryRepo(connection, repository)
+      else Resolver.artifactoryIvyRepo(connection, repository)
+    }
   )
 }

--- a/src/main/scala/net/rouly/sbt/artifactory/ArtifactoryPlugin.scala
+++ b/src/main/scala/net/rouly/sbt/artifactory/ArtifactoryPlugin.scala
@@ -1,4 +1,4 @@
-package io.jrouly.sbt.artifactory
+package net.rouly.sbt.artifactory
 
 import sbt._
 import sbt.plugins.JvmPlugin
@@ -11,7 +11,7 @@ object ArtifactoryPlugin extends AutoPlugin {
 
   override def trigger: sbt.PluginTrigger = allRequirements
 
-  object autoImport {
+  object autoImport extends ArtifactoryPluginKeys with ArtifactoryImplicits {
 
     def artifactoryHttp(hostname: String, path: String = "artifactory"): ArtifactoryUrl =
       ArtifactoryUrl("http", hostname, 80, path)
@@ -22,15 +22,6 @@ object ArtifactoryPlugin extends AutoPlugin {
     def artifactoryCloud(organization: String): ArtifactoryCloud =
       ArtifactoryCloud(organization)
 
-    final val artifactoryConnection = settingKey[ArtifactoryConnection]("Artifactory connection settings")
-
-    final val artifactoryRealm = settingKey[String]("Artifactory credential realm")
-
-    final val artifactorySnapshotRepository = settingKey[String]("Artifactory snapshot repository")
-    final val artifactoryReleaseRepository = settingKey[String]("Artifactory release repository")
-
-    final val artifactorySnapshotResolver = settingKey[URLRepository]("Artifactory snapshot resolver")
-    final val artifactoryReleaseResolver = settingKey[URLRepository]("Artifactory release resolver")
   }
 
   import autoImport._
@@ -48,14 +39,14 @@ object ArtifactoryPlugin extends AutoPlugin {
 
     Keys.credentials += Credentials(
       realm = artifactoryRealm.value,
-      host = artifactoryConnection.value.hostname,
+      host = artifactory.value.hostname,
       userName = sys.env.getOrElse("ARTIFACTORY_USER", "username"),
       passwd = sys.env.getOrElse("ARTIFACTORY_PASS", "password")
     )
   )
 
   private lazy val defaultSettings = Seq(
-    artifactoryConnection := artifactoryHttp("localhost", "artifactory"),
+    artifactory := artifactoryHttp("localhost", "artifactory"),
 
     artifactoryRealm := "Artifactory Realm",
 
@@ -73,30 +64,14 @@ object ArtifactoryPlugin extends AutoPlugin {
 
     artifactorySnapshotResolver := Def.settingDyn {
       val repository = artifactorySnapshotRepository.value
-      artifactoryResolver(repository)
+      if (Keys.publishMavenStyle.value) Resolver.artifactoryRepo(repository)
+      else Resolver.artifactoryIvyRepo(repository)
     }.value,
 
     artifactoryReleaseResolver := Def.settingDyn {
       val repository = artifactoryReleaseRepository.value
-      artifactoryResolver(repository)
+      if (Keys.publishMavenStyle.value) Resolver.artifactoryRepo(repository)
+      else Resolver.artifactoryIvyRepo(repository)
     }.value
   )
-
-  private def artifactoryResolver(repository: String): Def.Initialize[URLRepository] = Def.setting {
-    val repositoryUrl = {
-      artifactoryConnection.value match {
-        case ArtifactoryUrl(protocol, hostname, port, path) =>
-          val cleanProtocol = protocol.stripSuffix("://")
-          val cleanPath = path.stripPrefix("/").stripSuffix("/")
-          s"$cleanProtocol://$hostname:$port/$cleanPath/$repository"
-        case cloud @ ArtifactoryCloud(_) =>
-          s"https://${cloud.hostname}/artifactory/$repository"
-      }
-    }
-
-    val isInsecure = repositoryUrl.startsWith("http://")
-    val isMaven = Keys.publishMavenStyle.value
-    val pattern = if (isMaven) Resolver.mavenStylePatterns else Resolver.ivyStylePatterns
-    HandleInsecure(Resolver.url(repository, url(repositoryUrl))(pattern), isInsecure)
-  }
 }

--- a/src/main/scala/net/rouly/sbt/artifactory/ArtifactoryPluginKeys.scala
+++ b/src/main/scala/net/rouly/sbt/artifactory/ArtifactoryPluginKeys.scala
@@ -1,0 +1,17 @@
+package net.rouly.sbt.artifactory
+
+import sbt.{Resolver, settingKey}
+
+trait ArtifactoryPluginKeys {
+
+  final val artifactory = settingKey[ArtifactoryConnection]("Artifactory connection settings")
+
+  final val artifactoryRealm = settingKey[String]("Artifactory credential realm")
+
+  final val artifactorySnapshotRepository = settingKey[String]("Artifactory snapshot repository")
+  final val artifactoryReleaseRepository = settingKey[String]("Artifactory release repository")
+
+  final val artifactorySnapshotResolver = settingKey[Resolver]("Artifactory snapshot resolver")
+  final val artifactoryReleaseResolver = settingKey[Resolver]("Artifactory release resolver")
+
+}

--- a/src/sbt-test/project/build.properties
+++ b/src/sbt-test/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.4.6

--- a/src/sbt-test/sbt-artifactory/simple/build.sbt
+++ b/src/sbt-test/sbt-artifactory/simple/build.sbt
@@ -8,7 +8,7 @@ def checkImpl(projectName: String): Def.Initialize[Task[Unit]] = Def.task {
     case None => sys.error("No resolver defined.")
     case Some(resolver) =>
       if (!expectations(projectName).values.toSet.contains(resolver.toString)) {
-        println(projectName + " -> " + resolver.toString)
+        println(s"$projectName -> $resolver\nexpected:${expectations(projectName)}\n\n")
         sys.error("Resolver did not match expectations.")
       }
   }
@@ -26,7 +26,7 @@ lazy val snapshotIvyHttps = project
   .settings(
     isSnapshot := true,
     publishMavenStyle := false,
-    artifactoryConnection := artifactoryHttps(hostname = "example.com", path = "/path/to/artifacts/"),
+    artifactory := artifactoryHttps(hostname = "example.com"),
     check := checkImpl("snapshotIvyHttps").value
   )
 
@@ -34,7 +34,7 @@ lazy val snapshotIvyCloud = project
   .settings(
     isSnapshot := true,
     publishMavenStyle := false,
-    artifactoryConnection := artifactoryCloud("demo"),
+    artifactory := artifactoryCloud("demo"),
     check := checkImpl("snapshotIvyCloud").value
   )
 
@@ -42,7 +42,7 @@ lazy val releaseIvyHttps = project
   .settings(
     isSnapshot := false,
     publishMavenStyle := false,
-    artifactoryConnection := artifactoryHttps(hostname = "example.com", path = "/path/to/artifacts/"),
+    artifactory := artifactoryHttps(hostname = "example.com"),
     check := checkImpl("releaseIvyHttps").value
   )
 
@@ -50,7 +50,7 @@ lazy val releaseIvyCloud = project
   .settings(
     isSnapshot := false,
     publishMavenStyle := false,
-    artifactoryConnection := artifactoryCloud("demo"),
+    artifactory := artifactoryCloud("demo"),
     check := checkImpl("releaseIvyCloud").value
   )
 
@@ -58,7 +58,7 @@ lazy val snapshotMavenHttps = project
   .settings(
     isSnapshot := true,
     publishMavenStyle := true,
-    artifactoryConnection := artifactoryHttps(hostname = "example.com", path = "/path/to/artifacts/"),
+    artifactory := artifactoryHttps(hostname = "example.com"),
     check := checkImpl("snapshotMavenHttps").value
   )
 
@@ -66,7 +66,7 @@ lazy val snapshotMavenCloud = project
   .settings(
     isSnapshot := true,
     publishMavenStyle := true,
-    artifactoryConnection := artifactoryCloud("demo"),
+    artifactory := artifactoryCloud("demo"),
     check := checkImpl("snapshotMavenCloud").value
   )
 
@@ -74,7 +74,7 @@ lazy val releaseMavenHttps = project
   .settings(
     isSnapshot := false,
     publishMavenStyle := true,
-    artifactoryConnection := artifactoryHttps(hostname = "example.com", path = "/path/to/artifacts/"),
+    artifactory := artifactoryHttps(hostname = "example.com"),
     check := checkImpl("releaseMavenHttps").value
   )
 
@@ -82,49 +82,57 @@ lazy val releaseMavenCloud = project
   .settings(
     isSnapshot := false,
     publishMavenStyle := true,
-    artifactoryConnection := artifactoryCloud("demo"),
+    artifactory := artifactoryCloud("demo"),
     check := checkImpl("releaseMavenCloud").value
   )
 
 lazy val expectations: Map[String, Map[String, String]] = Map(
 
   "snapshotIvyHttps" -> Map(
-    "0.13" -> """URLRepository(ivy-snapshot-local,Patterns(ivyPatterns=List(https://example.com:443/path/to/artifacts/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=List(https://example.com:443/path/to/artifacts/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false))""",
-    "1.0" -> """URLRepository(ivy-snapshot-local, Patterns(ivyPatterns=Vector(https://example.com:443/path/to/artifacts/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(https://example.com:443/path/to/artifacts/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), false)"""
+    "0.13" -> """URLRepository(ivy-snapshot-local,Patterns(ivyPatterns=List(https://example.com:443/artifactory/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=List(https://example.com:443/artifactory/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false))""",
+    "1.0+" -> """URLRepository(ivy-snapshot-local, Patterns(ivyPatterns=Vector(https://example.com:443/artifactory/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(https://example.com:443/artifactory/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false))""",
+    "1.3+" -> """URLRepository(ivy-snapshot-local, Patterns(ivyPatterns=Vector(https://example.com:443/artifactory/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(https://example.com:443/artifactory/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), false)"""
   ),
 
   "snapshotIvyCloud" -> Map(
     "0.13" -> """URLRepository(ivy-snapshot-local,Patterns(ivyPatterns=List(https://demo.jfrog.io/artifactory/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=List(https://demo.jfrog.io/artifactory/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false))""",
-    "1.0" -> """URLRepository(ivy-snapshot-local, Patterns(ivyPatterns=Vector(https://demo.jfrog.io/artifactory/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(https://demo.jfrog.io/artifactory/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), false)"""
+    "1.0+" -> """URLRepository(ivy-snapshot-local, Patterns(ivyPatterns=Vector(https://demo.jfrog.io/artifactory/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(https://demo.jfrog.io/artifactory/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false))""",
+    "1.3+" -> """URLRepository(ivy-snapshot-local, Patterns(ivyPatterns=Vector(https://demo.jfrog.io/artifactory/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(https://demo.jfrog.io/artifactory/ivy-snapshot-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), false)"""
   ),
 
   "releaseIvyHttps" -> Map(
-    "0.13" -> """URLRepository(ivy-release-local,Patterns(ivyPatterns=List(https://example.com:443/path/to/artifacts/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=List(https://example.com:443/path/to/artifacts/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false))""",
-    "1.0" -> """URLRepository(ivy-release-local, Patterns(ivyPatterns=Vector(https://example.com:443/path/to/artifacts/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(https://example.com:443/path/to/artifacts/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), false)"""
+    "0.13" -> """URLRepository(ivy-release-local,Patterns(ivyPatterns=List(https://example.com:443/artifactory/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=List(https://example.com:443/artifactory/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false))""",
+    "1.0+" -> """URLRepository(ivy-release-local, Patterns(ivyPatterns=Vector(https://example.com:443/artifactory/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(https://example.com:443/artifactory/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false))""",
+    "1.3+" -> """URLRepository(ivy-release-local, Patterns(ivyPatterns=Vector(https://example.com:443/artifactory/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(https://example.com:443/artifactory/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), false)"""
   ),
 
   "releaseIvyCloud" -> Map(
     "0.13" -> """URLRepository(ivy-release-local,Patterns(ivyPatterns=List(https://demo.jfrog.io/artifactory/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=List(https://demo.jfrog.io/artifactory/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false))""",
-    "1.0" -> """URLRepository(ivy-release-local, Patterns(ivyPatterns=Vector(https://demo.jfrog.io/artifactory/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(https://demo.jfrog.io/artifactory/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), false)"""
+    "1.0+" -> """URLRepository(ivy-release-local, Patterns(ivyPatterns=Vector(https://demo.jfrog.io/artifactory/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(https://demo.jfrog.io/artifactory/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false))""",
+    "1.3+" -> """URLRepository(ivy-release-local, Patterns(ivyPatterns=Vector(https://demo.jfrog.io/artifactory/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(https://demo.jfrog.io/artifactory/ivy-release-local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), false)"""
   ),
 
   "snapshotMavenHttps" -> Map(
-    "0.13" -> """URLRepository(maven-snapshot-local,Patterns(ivyPatterns=List(), artifactPatterns=List(https://example.com:443/path/to/artifacts/maven-snapshot-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false))""",
-    "1.0" -> """URLRepository(maven-snapshot-local, Patterns(ivyPatterns=Vector(), artifactPatterns=Vector(https://example.com:443/path/to/artifacts/maven-snapshot-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false), false)"""
+    "0.13" -> """URLRepository(maven-snapshot-local,Patterns(ivyPatterns=List(), artifactPatterns=List(https://example.com:443/artifactory/maven-snapshot-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false))""",
+    "1.0+" -> """URLRepository(maven-snapshot-local, Patterns(ivyPatterns=Vector(), artifactPatterns=Vector(https://example.com:443/artifactory/maven-snapshot-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false))""",
+    "1.3+" -> """URLRepository(maven-snapshot-local, Patterns(ivyPatterns=Vector(), artifactPatterns=Vector(https://example.com:443/artifactory/maven-snapshot-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false), false)"""
   ),
 
   "snapshotMavenCloud" -> Map(
     "0.13" -> """URLRepository(maven-snapshot-local,Patterns(ivyPatterns=List(), artifactPatterns=List(https://demo.jfrog.io/artifactory/maven-snapshot-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false))""",
-    "1.0" -> """URLRepository(maven-snapshot-local, Patterns(ivyPatterns=Vector(), artifactPatterns=Vector(https://demo.jfrog.io/artifactory/maven-snapshot-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false), false)"""
+    "1.0+" -> """URLRepository(maven-snapshot-local, Patterns(ivyPatterns=Vector(), artifactPatterns=Vector(https://demo.jfrog.io/artifactory/maven-snapshot-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false))""",
+    "1.3+" -> """URLRepository(maven-snapshot-local, Patterns(ivyPatterns=Vector(), artifactPatterns=Vector(https://demo.jfrog.io/artifactory/maven-snapshot-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false), false)"""
   ),
 
   "releaseMavenHttps" -> Map(
-    "0.13" -> """URLRepository(maven-release-local,Patterns(ivyPatterns=List(), artifactPatterns=List(https://example.com:443/path/to/artifacts/maven-release-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false))""",
-    "1.0" -> """URLRepository(maven-release-local, Patterns(ivyPatterns=Vector(), artifactPatterns=Vector(https://example.com:443/path/to/artifacts/maven-release-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false), false)"""
+    "0.13" -> """URLRepository(maven-release-local,Patterns(ivyPatterns=List(), artifactPatterns=List(https://example.com:443/artifactory/maven-release-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false))""",
+    "1.0+" -> """URLRepository(maven-release-local, Patterns(ivyPatterns=Vector(), artifactPatterns=Vector(https://example.com:443/artifactory/maven-release-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false))""",
+    "1.3+" -> """URLRepository(maven-release-local, Patterns(ivyPatterns=Vector(), artifactPatterns=Vector(https://example.com:443/artifactory/maven-release-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false), false)"""
   ),
 
   "releaseMavenCloud" -> Map(
     "0.13" -> """URLRepository(maven-release-local,Patterns(ivyPatterns=List(), artifactPatterns=List(https://demo.jfrog.io/artifactory/maven-release-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false))""",
-    "1.0" -> """URLRepository(maven-release-local, Patterns(ivyPatterns=Vector(), artifactPatterns=Vector(https://demo.jfrog.io/artifactory/maven-release-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false), false)"""
+    "1.0+" -> """URLRepository(maven-release-local, Patterns(ivyPatterns=Vector(), artifactPatterns=Vector(https://demo.jfrog.io/artifactory/maven-release-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false))""",
+    "1.3+" -> """URLRepository(maven-release-local, Patterns(ivyPatterns=Vector(), artifactPatterns=Vector(https://demo.jfrog.io/artifactory/maven-release-local/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]), isMavenCompatible=true, descriptorOptional=false, skipConsistencyCheck=false), false)"""
   )
 )

--- a/src/sbt-test/sbt-artifactory/simple/project/plugin.sbt
+++ b/src/sbt-test/sbt-artifactory/simple/project/plugin.sbt
@@ -1,4 +1,4 @@
 sys.props.get("plugin.version") match {
-  case Some(x) => addSbtPlugin("io.jrouly" % "sbt-artifactory" % x)
+  case Some(x) => addSbtPlugin("net.rouly" % "sbt-artifactory" % x)
   case _ => sys.error("The system property 'plugin.version' is not defined.")
 }


### PR DESCRIPTION
Supports:
```scala
resolvers += Resolver.artifactoryIvyRepo(artifactory.value, "ivy-release")
resolvers += Resolver.artifactoryRepo(artifactory.value, "maven-release")
```

Changes the key `artifactoryConnection` to `artifactory`.

Also changes the organization name from `io.jrouly` to `net.rouly`.